### PR TITLE
Fix deleting download directory

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -21,6 +21,10 @@ download_bats() {
     echo "* Downloading Bats-core(version:$version) to $download_path"
     git clone --depth=1 -b "v$version" "$repo_url" "$download_path" >/dev/null
 
+    # remove `.git` dir, because (a) we don't need it, and (b) asdf has a hard time
+    # removing it (lacks the `-f` parameter with the `rm` command)
+    rm -rf "$download_path/.git"
+
     echo "Download successful."
     return 0
   ) || (

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -29,11 +29,14 @@ teardown() {
   # check if temp download path exists
   [[ -d "$temp_download_path" ]]
 
-  local files
-  files=$(ls -A "$temp_download_path")
-
   # temp download path should include install script
-  [[ "$files" =~ "install.sh" ]]
+  [[ -f "$temp_download_path/install.sh" ]]
+
+  # temp download path should NOT include .git dir
+  # we don't need it, and asdf has trouble deleting it
+  # because it doesn't use the --force (-f) parameter
+  # with `rm`
+  [[ ! -d "$temp_download_path/.git" ]]
 }
 
 @test 'success if ASDF params are set' {
@@ -46,11 +49,14 @@ teardown() {
   # check if temp download path exists
   [[ -d "$temp_download_path" ]]
 
-  local files
-  files=$(ls -A "$temp_download_path")
-
   # temp download path should include install script
-  [[ "$files" =~ "install.sh" ]]
+  [[ -f "$temp_download_path/install.sh" ]]
+
+  # temp download path should NOT include .git dir
+  # we don't need it, and asdf has trouble deleting it
+  # because it doesn't use the --force (-f) parameter
+  # with `rm`
+  [[ ! -d "$temp_download_path/.git" ]]
 
   unset ASDF_DOWNLOAD_PATH
   unset ASDF_INSTALL_VERSION

--- a/tests/download.bats
+++ b/tests/download.bats
@@ -4,7 +4,7 @@ setup() {
   export bin_path
   bin_path=$(readlink -e "$BATS_TEST_DIRNAME/../bin")
   export cmd="download"
-  export test_version="v1.2.0"
+  export test_version="1.2.0"
 
   export temp_download_path="/tmp/bats_$RANDOM"
   mkdir -p "$temp_download_path"

--- a/tests/list-all.bats
+++ b/tests/list-all.bats
@@ -17,11 +17,11 @@ main() {
 
   # check versions
   echo "$output"
-  [[ "$output" =~ "v0.1.0" ]]
-  [[ "$output" =~ "v0.2.0" ]]
+  [[ "$output" =~ "0.1.0" ]]
+  [[ "$output" =~ "0.2.0" ]]
 
   # check that versions are on same line
-  [[ "$output" =~ "v0.1.0 v0.2.0" ]]
+  [[ "$output" =~ "0.1.0 0.2.0" ]]
 }
 
 @test 'success if called with param' {


### PR DESCRIPTION
When trying to install bats, I get this output:

```plaintext
[truncated for brevity...]
Download successful.
* Installing Bats to /home/phil/.asdf/installs/bats/1.11.0
Installed Bats to /home/phil/.asdf/installs/bats/1.11.0/bin/bats
* successfully installed to /home/phil/.asdf/installs/bats/1.11.0
rm: remove write-protected regular file '/home/phil/.asdf/downloads/bats/1.11.0/.git/objects/pack/pack-0a8b7a922c2a9a3d08e02492fe10fb630cb4ad42.idx'?
```

... and it waits for me to interactively hit `y` at least 3 times before it will delete the download directory.

This PR makes three changes:

1. fixes tests so they pass (`v` in version number issue, see #10)
2. deletes the `.git` directory with an `rm -rf` after cloning the repo
3. checks that the `.git` directory isn't there in tests

## to test

```bash
asdf plugin remove bats
asdf plugin add bats git@github.com:pcrockett/asdf-bats.git
asdf install bats latest
asdf local bats latest
bats --version
```